### PR TITLE
be sure to have latest ubuntu-debootstrap before building cedarish image

### DIFF
--- a/cedar14/Makefile
+++ b/cedar14/Makefile
@@ -5,6 +5,7 @@ build: build/cedar14.tar
 
 build/cedar14.tar:
 	mkdir -p build
+	docker pull $(CEDAR14_BASE)
 	docker run --name cedar14-build \
 		-v $(shell pwd)/cedar-14.sh:/mnt/build.sh \
 		-v $(shell pwd)/patches:/mnt/patches \


### PR DESCRIPTION
I don't know how CircleCI works, but it may be a good idea to pull $(CEDAR14_BASE) before building the cedarish image to be sure we have latest ubuntu-debootstrap in case it was already pulled before.